### PR TITLE
Avoid using needless safe navigation operator

### DIFF
--- a/lib/ueki/http_client/request_body_converter.rb
+++ b/lib/ueki/http_client/request_body_converter.rb
@@ -13,7 +13,7 @@ module Ueki
 
         case content_type
         when "application/json"
-          params&.to_json
+          params.to_json
         when "application/x-www-form-urlencoded"
           URI.encode_www_form(params)
         else


### PR DESCRIPTION
I removed needless safe navigation operator.
If `params` is `nil`, `Ueki::HttpClient::RequestBodyConverter#call` will return early.
https://github.com/tmimura39/ueki/blob/49740c2d588bf2d7f168d34516ced37b3078d29e/lib/ueki/http_client/request_body_converter.rb#L11-L12